### PR TITLE
Proposition d'amélioration pour personnaliser l'envoi des mails par site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,8 @@
     <tag>HEAD</tag>
   </scm>
     <properties>
-        <export-package>org.jahia.modules.newsletter</export-package>
+    	<!-- Sub-package export to be available for other modules : Make it possible to register newsletter from other module actions as before in 6.6 -->
+        <export-package>org.jahia.modules.newsletter,org.jahia.modules.newsletter.service,org.jahia.modules.newsletter.service.model</export-package>
         <jahia-module-type>jahiapp</jahia-module-type>
         <jahia-depends>default,siteSettings,tasks,grid</jahia-depends>
     </properties>

--- a/src/main/java/org/jahia/modules/newsletter/action/SubscribeAction.java
+++ b/src/main/java/org/jahia/modules/newsletter/action/SubscribeAction.java
@@ -85,6 +85,7 @@ import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.JCRTemplate;
 import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.mail.MailService;
+import org.jahia.services.content.decorator.JCRSiteNode;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;

--- a/src/main/java/org/jahia/modules/newsletter/action/SubscribeAction.java
+++ b/src/main/java/org/jahia/modules/newsletter/action/SubscribeAction.java
@@ -231,7 +231,24 @@ public class SubscribeAction extends Action {
                     + node.getLanguage() + node.getPath() + ".confirm.do?key="+confirmationKey+"&exec=add");
             try {
             	String modulePackageNameToUse = getTemplateName(mailConfirmationTemplate,node, locale,"Jahia Newsletter");
-                mailService.sendMessageWithTemplate(mailConfirmationTemplate, bindings, email, mailService.defaultSender(), null, null,
+				String mailSender = mailService.defaultSender();
+
+		        try {
+		            JCRSiteNode siteNode = node.getResolveSite();
+
+		            if (siteNode.isNodeType("jmix:newsletterSender")) {
+		                String newMailSender = siteNode.getPropertyAsString(
+		                        "newsletterMailSender");
+
+		                if ((newMailSender != null) &&
+		                        !"".equals(newMailSender.trim())) {
+		                    mailSender = newMailSender;
+		                }
+		            }
+		        } catch (Exception ue) {
+		            logger.debug(ue.getMessage(), ue);
+		        }
+                mailService.sendMessageWithTemplate(mailConfirmationTemplate, bindings, email, mailSender, null, null,
                         locale, modulePackageNameToUse);
             } catch (ScriptException e) {
                 logger.error("Cannot generate confirmation mail",e);

--- a/src/main/java/org/jahia/modules/newsletter/action/UnsubscribeAction.java
+++ b/src/main/java/org/jahia/modules/newsletter/action/UnsubscribeAction.java
@@ -223,7 +223,24 @@ public class UnsubscribeAction extends Action {
             bindings.put("confirmationlink", generateUnsubscribeLink(node, confirmationKey, req));
             try {
             	String modulePackageNameToUse = getTemplateName(mailConfirmationTemplate,node, resource.getLocale(),"Jahia Newsletter");
-                mailService.sendMessageWithTemplate(mailConfirmationTemplate, bindings, email, mailService.defaultSender(), null, null, resource.getLocale(), modulePackageNameToUse);
+				String mailSender = mailService.defaultSender();
+
+		        try {
+		            JCRSiteNode siteNode = node.getResolveSite();
+
+		            if (siteNode.isNodeType("jmix:newsletterSender")) {
+		                String newMailSender = siteNode.getPropertyAsString(
+		                        "newsletterMailSender");
+
+		                if ((newMailSender != null) &&
+		                        !"".equals(newMailSender.trim())) {
+		                    mailSender = newMailSender;
+		                }
+		            }
+		        } catch (Exception ue) {
+		            logger.debug(ue.getMessage(), ue);
+		        }
+                mailService.sendMessageWithTemplate(mailConfirmationTemplate, bindings, email, mailSender, null, null, resource.getLocale(), modulePackageNameToUse);
             } catch (ScriptException e) {
                 logger.error("Cannot generate confirmation mail",e);
             }

--- a/src/main/java/org/jahia/modules/newsletter/action/UnsubscribeAction.java
+++ b/src/main/java/org/jahia/modules/newsletter/action/UnsubscribeAction.java
@@ -85,6 +85,7 @@ import org.jahia.services.content.JCRSessionWrapper;
 import org.jahia.services.content.JCRTemplate;
 import org.jahia.services.content.decorator.JCRUserNode;
 import org.jahia.services.mail.MailService;
+import org.jahia.services.content.decorator.JCRSiteNode;
 import org.jahia.services.render.RenderContext;
 import org.jahia.services.render.Resource;
 import org.jahia.services.render.URLResolver;

--- a/src/main/java/org/jahia/modules/newsletter/action/UnsubscribeAction.java
+++ b/src/main/java/org/jahia/modules/newsletter/action/UnsubscribeAction.java
@@ -71,11 +71,14 @@
  */
 package org.jahia.modules.newsletter.action;
 
+import org.apache.commons.lang.StringUtils;
 import org.jahia.bin.Action;
 import org.jahia.bin.ActionResult;
 import org.jahia.bin.Jahia;
 import org.jahia.bin.Render;
+import org.jahia.data.templates.JahiaTemplatesPackage;
 import org.jahia.modules.newsletter.service.SubscriptionService;
+import org.jahia.registries.ServicesRegistry;
 import org.jahia.services.content.JCRCallback;
 import org.jahia.services.content.JCRNodeWrapper;
 import org.jahia.services.content.JCRSessionWrapper;
@@ -98,6 +101,7 @@ import javax.script.ScriptException;
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
@@ -130,6 +134,32 @@ public class UnsubscribeAction extends Action {
 		        + newsletterNode.getLanguage() + newsletterNode.getPath()
 		        + ".confirm.do?key=" + confirmationKey + "&exec=rem";
 	}
+	
+	/**
+	* Check if templatSet has mail template
+	*/
+    private String getTemplateName(String template, JCRNodeWrapper node,  final Locale locale, String defaultTemplate){
+    	String templateToReturn = defaultTemplate;
+
+    	try {
+	    	//try if it is multilingual
+	        String suffix = StringUtils.substringAfterLast(template, ".");
+	    	String languageMailConfTemplate = template.substring(0, template.length() - (suffix.length()+1)) + "_" + locale.toString() + "." + suffix;
+	    	String templatePackageName = node.getResolveSite().getTemplatePackageName();
+	    	JahiaTemplatesPackage templatePackage = ServicesRegistry.getInstance().getJahiaTemplateManagerService().getTemplatePackage(templatePackageName);
+	    	org.springframework.core.io.Resource templateRealPath = templatePackage.getResource(languageMailConfTemplate);
+	    	if(templateRealPath == null) {
+	          templateRealPath = templatePackage.getResource(template);
+	    	}
+	    	if (templateRealPath!=null){
+	    		templateToReturn = templatePackageName;
+	    	}
+    	} catch (Exception ue){
+    		logger.error("Error resolving template for site");
+    	}
+
+    	return templateToReturn;
+    }
 
     public ActionResult doExecute(final HttpServletRequest req, final RenderContext renderContext,
                                   final Resource resource, JCRSessionWrapper session, final Map<String, List<String>> parameters, URLResolver urlResolver)
@@ -192,7 +222,8 @@ public class UnsubscribeAction extends Action {
             bindings.put("newsletter", node);
             bindings.put("confirmationlink", generateUnsubscribeLink(node, confirmationKey, req));
             try {
-                mailService.sendMessageWithTemplate(mailConfirmationTemplate, bindings, email, mailService.defaultSender(), null, null, resource.getLocale(), "Jahia Newsletter");
+            	String modulePackageNameToUse = getTemplateName(mailConfirmationTemplate,node, resource.getLocale(),"Jahia Newsletter");
+                mailService.sendMessageWithTemplate(mailConfirmationTemplate, bindings, email, mailService.defaultSender(), null, null, resource.getLocale(), modulePackageNameToUse);
             } catch (ScriptException e) {
                 logger.error("Cannot generate confirmation mail",e);
             }

--- a/src/main/java/org/jahia/modules/newsletter/service/NewsletterService.java
+++ b/src/main/java/org/jahia/modules/newsletter/service/NewsletterService.java
@@ -286,10 +286,27 @@ public class NewsletterService {
         String out = newsletterVersions.get(key);
         String subject = newsletterVersions.get(key + ".title");
         if (logger.isDebugEnabled()) {
-            logger.debug("Send newsltter to " + email + " , subject " + subject);
+            logger.debug("Send newsletter to " + email + " , subject " + subject);
             logger.debug(out);
         }
-        return mailService.sendHtmlMessage(mailService.defaultSender(), email, null, null, subject, out);
+		String mailSender = mailService.defaultSender();
+
+        try {
+            JCRSiteNode siteNode = node.getResolveSite();
+
+            if (siteNode.isNodeType("jmix:newsletterSender")) {
+                String newMailSender = siteNode.getPropertyAsString(
+                        "newsletterMailSender");
+
+                if ((newMailSender != null) &&
+                        !"".equals(newMailSender.trim())) {
+                    mailSender = newMailSender;
+                }
+            }
+        } catch (Exception ue) {
+            logger.debug(ue.getMessage(), ue);
+        }
+        return mailService.sendHtmlMessage(mailSender, email, null, null, subject, out);
     }
 
     public List<JCRNodeWrapper> getSiteNewsletters(JCRSiteNode site, String orderBy, boolean orderAscending, JCRSessionWrapper session){

--- a/src/main/resources/META-INF/definitions.cnd
+++ b/src/main/resources/META-INF/definitions.cnd
@@ -6,6 +6,14 @@
 <jmix = 'http://www.jahia.org/jahia/mix/1.0'>
 
 //---------------------------------------------------------
+//Modification SPW pour mailsender
+//---------------------------------------------------------
+[jmix:newsletterSender] mixin
+ extends=jnt:virtualsite
+ itemtype=options
+ - newsletterMailSender (string) nofulltext
+
+//---------------------------------------------------------
 // Subscriptions
 //---------------------------------------------------------
 

--- a/src/main/resources/META-INF/spring/mod-newsletter.xml
+++ b/src/main/resources/META-INF/spring/mod-newsletter.xml
@@ -3,9 +3,12 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
        xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:osgi="http://www.springframework.org/schema/osgi"
        xmlns:util="http://www.springframework.org/schema/util"
        xsi:schemaLocation="http://www.springframework.org/schema/beans
        http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+       http://www.springframework.org/schema/osgi
+       http://www.springframework.org/schema/osgi/spring-osgi.xsd
        http://www.springframework.org/schema/mvc
        http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
 
@@ -46,4 +49,7 @@
         <property name="unsubscriptionConfirmationPagePath" value="${newsletterUnsubscriptionConfirmationPagePath:/nl-unsubscribe-confirm}"/>
         <property name="requireAuthenticatedUser" value="${newsletterConfirmationRequireAuthenticatedUser:false}"/>
     </bean>
+    <osgi:service id="ExternalSubscriptionService" 
+    	ref="subscriptionService" 
+	interface="org.jahia.modules.newsletter.service.SubscriptionService"/>
 </beans>

--- a/src/main/resources/resources/JahiaNewsletter.properties
+++ b/src/main/resources/resources/JahiaNewsletter.properties
@@ -153,3 +153,6 @@ newsletter.successfully.published=Newsletter '{0}' successfully published
 newsletter.issue.successfully.published=Issue '{0}' successfully published
 newsletter.issue.needPublish=You have to publish this issue
 newsletter.needPublish=You have to publish this newsletter
+
+jmix_newsletterSender=Newsletter parameter to define sender
+jmix_newsletterSender.newsletterMailSender=Sender email address

--- a/src/main/resources/resources/JahiaNewsletter_fr.properties
+++ b/src/main/resources/resources/JahiaNewsletter_fr.properties
@@ -149,3 +149,6 @@ newsletter.successfully.updated=Newsletter '{0}' mise à jour avec succès
 siteSettings.label.newsletterManager=Gérer les newsletters
 subscribeConfirmation.subject=Merci de confirmer votre nouvel abonnement
 unsubscribeConfirmation.subject=Merci de confirmer votre désabonnement
+
+jmix_newsletterSender=Paramètres d'envoi pour la newsletter
+jmix_newsletterSender.newsletterMailSender=Adresse mail de l'expéditeur


### PR DESCRIPTION
- Création d'un mixin pour le site : 
  Possibilité d'introduire une adresse mail + traduction anglaise (default) et française

```
//---------------------------------------------------------
//Modification SPW pour mailsender
//---------------------------------------------------------
[jmix:newsletterSender] mixin
 extends=jnt:virtualsite
 itemtype=options
 - newsletterMailSender (string) nofulltext
```
- Modification du service pour exploiter cette adresse mail
- Modification des actions de souscription pour prendre le template de mail dans le templateSet du site et exploiter cette adresse mail
- Certains développements exploitent le "SubscriptionService" dans leurs actions pour inscrire leurs utilisateurs. Les classes n'étaient plus exposées, le fichier POM a été modifié en ce sens.
